### PR TITLE
Update resample logic

### DIFF
--- a/conda/snow_viz.yaml
+++ b/conda/snow_viz.yaml
@@ -2,6 +2,7 @@ name: snow_viz
 channels:
 - conda-forge
 dependencies:
+- asyncssh
 - dask
 - flox
 - geopandas

--- a/docs/postgresql_setup.md
+++ b/docs/postgresql_setup.md
@@ -1,0 +1,41 @@
+# Install via conda
+```
+conda env create -n postgresql postgis
+```
+
+# Create new cluster
+```shell
+initdb -D /path/to/db_home
+```
+
+# (Optional) Allow connections from outside
+* Edit `postgresql.conf`
+```
+listen_addresses = '*'
+```
+* Edit `pg_hba.conf` and add allowed IP address
+
+# Activate postgis and raster extensions on new DB
+```sql
+CREATE EXTENSION postgis;
+CREATE EXTENSION postgis_raster;
+```
+
+# Sample import of NetCDF
+Options from:
+https://postgis.net/docs/using_raster_dataman.html
+`I` -> Create index
+`l` -> Overviews
+
+```
+raster2pgsql -I -C -e -Y -l 2 -s 4269 -F -t 32x32 NETCDF:"4km_SWE_Depth_WY1982_v01.nc":SWE wy_1982 | psql -h honduras -d swannData
+```
+
+# Sample import of Shapefile
+https://postgis.net/docs/using_postgis_dbmanagement.html#shp2pgsql_usage
+```
+shp2pgsql -c -s 4269 -i -I CBRFC_Zones_UC.shp CBRFC_Zones_UC | psql -h honduras -d swannData
+```
+
+# Reads
+https://www.crunchydata.com/blog/postgres-raster-query-basics

--- a/notebooks/GeoPandas.ipynb
+++ b/notebooks/GeoPandas.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f0e23d5-50d9-480e-bc22-fbb2e666beb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "import geopandas as gp\n",
+    "\n",
+    "from nb_shared import *\n",
+    "\n",
+    "from swe_compare.nb_helpers import start_cluster\n",
+    "from swe_compare import CBRFCZone, Snow17SWE, ZoneCompare\n",
+    "from swe_compare.rasterize_zone import cbrfc_zone_mask_as_xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b04712ea-5421-4d14-a3f1-6ed672c9a3e1",
+   "metadata": {},
+   "source": [
+    "# Description\n",
+    "\n",
+    "Notebook to spatially join a rasterized CBRFC zone with the centers of the grid cells of a SWANN data set.  \n",
+    "This was not successful as the centers do not all overlap with a zone polygon at that location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b550bad-102f-44c2-b949-51fd722009f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperColorado = CBRFCZone(UC_ZONES)\n",
+    "cbrfc_zones = cbrfc_zone_mask_as_xr(UC_ZONE_TIF, upperColorado)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68e04acf-01cc-4cd9-9fc2-b41b13429116",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s17_swe = Snow17SWE(\n",
+    "    SWE_HOME_DIR + 'CBRFC_Gunnison_1981_2020_SWE_inches.csv',\n",
+    ")\n",
+    "target_zones = list(s17_swe.csv.columns)\n",
+    "target_zones = upperColorado.target_zones_as_dict(target_zones)\n",
+    "target_zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3df8716e-7644-421f-94b5-12814939340d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_huf = upperColorado.shapefile.query(\"zone == 'ALEC2HUF'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d5d3158-c411-419d-90bc-4fbf33e2e20f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_huf.bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fd6f3c7-191e-4823-af04-5cbf15154898",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swann = xr.open_mfdataset(\n",
+    "    SWANN_HOME_DIR + '*2019_v01.nc',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22a3c00d-baa6-4851-9848-4e166a46e0ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swann = swann.SWE.sel(\n",
+    "    lat=slice(alec2_huf.bounds.miny.values[0], alec2_huf.bounds.maxy.values[0]),\n",
+    "    lon=slice(alec2_huf.bounds.minx.values[0], alec2_huf.bounds.maxx.values[0]),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "712daa73-b9fa-4520-a1ea-ee2549df7760",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = swann.isel(time=[0]).to_dataframe().reset_index()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2339ae62-3e28-4b8f-8738-867b13daa53a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swann_gp = gp.GeoDataFrame(\n",
+    "    df, geometry=gp.points_from_xy(df.lon,df.lat, crs=\"EPSG:4269\")\n",
+    ")\n",
+    "\n",
+    "swann_gp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2c3d4be-e25c-4861-a0b3-d36004d26cd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_swann_swe = alec2_huf.sjoin(swann_gp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "249bbb53-80f7-44cc-8d0c-af83fc7bb804",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_swann_swe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e58a838-4dbb-40a6-aea6-8eb482fbd859",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "snow-viz",
+   "language": "python",
+   "name": "snow-viz"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Grid-Compare.ipynb
+++ b/notebooks/Grid-Compare.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ec00836-f168-4e32-a612-0ebc696651b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "\n",
+    "import geopandas as gp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from nb_shared import *\n",
+    "\n",
+    "from swe_compare.nb_helpers import start_cluster\n",
+    "from swe_compare import CBRFCZone, Snow17SWE, ZoneCompare\n",
+    "from swe_compare.rasterize_zone import \\\n",
+    "    cbrfc_zone_mask_as_xr, single_cbrfc_zone_mask_as_xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d531e8f-ef54-44ab-bb0c-fadfa61f016d",
+   "metadata": {},
+   "source": [
+    "# Description\n",
+    "\n",
+    "This notebook rasterizes a single CBRFC zone shape into a gridded raster based on the SWANN raster grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b550bad-102f-44c2-b949-51fd722009f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperColorado = CBRFCZone(UC_ZONES)\n",
+    "cbrfc_zones = cbrfc_zone_mask_as_xr(UC_ZONE_TIF, upperColorado)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68e04acf-01cc-4cd9-9fc2-b41b13429116",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s17_swe = Snow17SWE(\n",
+    "    SWE_HOME_DIR + 'CBRFC_Gunnison_1981_2020_SWE_inches.csv',\n",
+    ")\n",
+    "target_zones = list(s17_swe.csv.columns)\n",
+    "target_zones = upperColorado.target_zones_as_dict(target_zones)\n",
+    "target_zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3df8716e-7644-421f-94b5-12814939340d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_huf = upperColorado.shapefile.query(\"zone == 'ALEC2HUF'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d5d3158-c411-419d-90bc-4fbf33e2e20f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_huf.bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fd6f3c7-191e-4823-af04-5cbf15154898",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swann = xr.open_mfdataset(\n",
+    "    SWANN_HOME_DIR + 'SWE_Mask_v01.nc',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30d5d70c-b5d1-4f53-84d2-33ecad73979a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bottom_right = swann.sel(\n",
+    "    lat=alec2_huf.bounds.miny.values[0],\n",
+    "    lon=alec2_huf.bounds.minx.values[0],\n",
+    "    method=\"nearest\"\n",
+    ")\n",
+    "top_left = swann.sel(\n",
+    "    lat=alec2_huf.bounds.maxy.values[0],\n",
+    "    lon=alec2_huf.bounds.maxx.values[0],\n",
+    "    method=\"nearest\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1423e597-2284-4716-99c3-50c6e224b5c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "top_left"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "104d5569-0166-4ea5-84ab-aae08c095b63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bottom_right"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4448b68a-0259-498f-a3ec-b5ed54251d92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lat_mean_diff = np.mean(np.diff(swann.lat.values)) / 2\n",
+    "print(lat_mean_diff)\n",
+    "lon_mean_diff = np.mean(np.diff(swann.lon.values)) / 2\n",
+    "print(lon_mean_diff)\n",
+    "lat_values = swann.lat.values - lat_mean_diff\n",
+    "# lat_values = np.insert(lat_values, 0, lat_values[-1] + lon_mean_diff)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ecc9632-5241-415e-819e-8cd166d3e854",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_huf_tif = single_cbrfc_zone_mask_as_xr(\n",
+    "    UC_ZONE_TIF, alec2_huf\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45beea48-aab5-4dea-b91b-0ec7c7e61f74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alec2_huf_tif = alec2_huf_tif.sel(\n",
+    "    lat=slice(alec2_huf.bounds.miny.values[0], alec2_huf.bounds.maxy.values[0]),\n",
+    "    lon=slice(alec2_huf.bounds.minx.values[0], alec2_huf.bounds.maxx.values[0]),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0d1fbab-83eb-4544-b7b2-a9fc8c8bdba3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(dpi=150)\n",
+    "ax = fig.gca()\n",
+    "alec2_huf_tif.zone.plot(ax=ax)\n",
+    "alec2_huf.plot(ax=ax, color='orange')\n",
+    "ax.hlines(lat_values, -108, -106, color='black', lw=1, ls=':')\n",
+    "ax.vlines(swann.lon.values - lon_mean_diff, 38, 40, color='black', lw=1, ls=':')\n",
+    "ax.set_xlim(alec2_huf.bounds.minx.values[0], alec2_huf.bounds.maxx.values[0])\n",
+    "ax.set_ylim(alec2_huf.bounds.miny.values[0], alec2_huf.bounds.maxy.values[0])\n",
+    "ax.tick_params(axis='x', rotation=-25)\n",
+    "ax.set_title('SWANN grid');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f2063d3-b502-42f7-b86e-8b8a5548951a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "snow-viz",
+   "language": "python",
+   "name": "snow-viz"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/SWANN_blue.ipynb
+++ b/notebooks/SWANN_blue.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27b54c4a-05cc-4292-8676-3e9d3e4d3273",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nb_shared import *\n",
+    "from swe_compare.nb_helpers import start_cluster\n",
+    "from swe_compare import CBRFCZone, Snow17SWE, ZoneCompare\n",
+    "from swe_compare.swann_helpers import combine_cbrfc_swann, swann_swe_for_zones"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1498c828-ad71-4423-b24d-ff845b65d40e",
+   "metadata": {},
+   "source": [
+    "### Cluster for batch processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e2aa230-37f2-4208-bbf2-b0b3c1ed6b3d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster = start_cluster(n_workers=20, local=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a41f992-5e39-4b35-9c66-452a3b76abf9",
+   "metadata": {},
+   "source": [
+    "## Snow-17 SWE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a662fd4-8e9d-4551-bac5-a67fec79f1cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s17_swe = Snow17SWE(\n",
+    "    SWE_HOME_DIR + 'CBRFC_Blue_1981_2020_SWE_inches.csv',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "171c8098-2532-4df4-b65a-0fadd377b5ba",
+   "metadata": {},
+   "source": [
+    "## CBRFC Zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbc39af0-22a0-47e4-ac7d-e68f676da01a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperColorado = CBRFCZone(UC_ZONES)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87bbf832-21b1-46a7-96da-ebabaeecbc21",
+   "metadata": {},
+   "source": [
+    "## Target comparison zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f31ea80-31b3-474c-b9cf-2ca68304ea7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_zones = list(s17_swe.csv.columns)\n",
+    "target_zones = upperColorado.target_zones_as_dict(target_zones)\n",
+    "target_zones"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "274bab58-b3f2-4533-97e5-a509d9b2a9cd",
+   "metadata": {},
+   "source": [
+    "## SWANN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bc0e30a-1f82-4d8b-81f2-4ba13c7be386",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swann_swe_target_zones = swann_swe_for_zones(\n",
+    "    SWANN_HOME_DIR + '*.nc', \n",
+    "    UC_ZONE_TIF, \n",
+    "    upperColorado,\n",
+    "    target_zones,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18f0ab46-7a03-4cab-afab-332b37ba873e",
+   "metadata": {},
+   "source": [
+    "# Comparison "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "767f571d-ca7b-455b-9780-a5e609d32dca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compare = ZoneCompare(\n",
+    "    target_zones, \n",
+    "    s17_swe.csv, \n",
+    "    swann_swe_target_zones,\n",
+    "    range(1982, 2020)\n",
+    ")\n",
+    "\n",
+    "compare.save_html(HTML_OUTPUT + 'blue')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5a0473-4e64-4b66-988a-bcf17b901713",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.shutdown()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "snow-viz",
+   "language": "python",
+   "name": "snow-viz"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/SWANN_gunnison.ipynb
+++ b/notebooks/SWANN_gunnison.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27b54c4a-05cc-4292-8676-3e9d3e4d3273",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nb_shared import *\n",
+    "from swe_compare.nb_helpers import start_cluster\n",
+    "from swe_compare import CBRFCZone, Snow17SWE, ZoneCompare\n",
+    "from swe_compare.swann_helpers import combine_cbrfc_swann, swann_swe_for_zones"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1498c828-ad71-4423-b24d-ff845b65d40e",
+   "metadata": {},
+   "source": [
+    "### Cluster for batch processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e2aa230-37f2-4208-bbf2-b0b3c1ed6b3d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster = start_cluster(n_workers=20, local=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a41f992-5e39-4b35-9c66-452a3b76abf9",
+   "metadata": {},
+   "source": [
+    "## Snow-17 SWE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a662fd4-8e9d-4551-bac5-a67fec79f1cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gunnison_s17_swe = Snow17SWE(\n",
+    "    SWE_HOME_DIR + 'CBRFC_Gunnison_1981_2020_SWE_inches.csv',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "171c8098-2532-4df4-b65a-0fadd377b5ba",
+   "metadata": {},
+   "source": [
+    "## CBRFC Zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbc39af0-22a0-47e4-ac7d-e68f676da01a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperColorado = CBRFCZone(UC_ZONES)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87bbf832-21b1-46a7-96da-ebabaeecbc21",
+   "metadata": {},
+   "source": [
+    "## Target comparison zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f31ea80-31b3-474c-b9cf-2ca68304ea7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_zones = list(gunnison_s17_swe.csv.columns)\n",
+    "target_zones = upperColorado.target_zones_as_dict(target_zones)\n",
+    "target_zones"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "274bab58-b3f2-4533-97e5-a509d9b2a9cd",
+   "metadata": {},
+   "source": [
+    "## SWANN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bc0e30a-1f82-4d8b-81f2-4ba13c7be386",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "swann_swe_target_zones = swann_swe_for_zones(\n",
+    "    SWANN_HOME_DIR + '*.nc', \n",
+    "    UC_ZONE_TIF, \n",
+    "    upperColorado,\n",
+    "    target_zones,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18f0ab46-7a03-4cab-afab-332b37ba873e",
+   "metadata": {},
+   "source": [
+    "# Comparison "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "767f571d-ca7b-455b-9780-a5e609d32dca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gunnison_compare = ZoneCompare(target_zones, gunnison_s17_swe.csv, swann_swe_target_zones)\n",
+    "plots = [gunnison_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
+    "all = hv.Layout(plots).cols(2)\n",
+    "\n",
+    "# pn.pane.HoloViews(all).save('gunnison', embed=True, resources=INLINE)\n",
+    "# all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5a0473-4e64-4b66-988a-bcf17b901713",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.shutdown()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "snow-viz",
+   "language": "python",
+   "name": "snow-viz"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/SWANN_gunnison.ipynb
+++ b/notebooks/SWANN_gunnison.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gunnison_s17_swe = Snow17SWE(\n",
+    "s17_swe = Snow17SWE(\n",
     "    SWE_HOME_DIR + 'CBRFC_Gunnison_1981_2020_SWE_inches.csv',\n",
     ")"
    ]
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "target_zones = list(gunnison_s17_swe.csv.columns)\n",
+    "target_zones = list(s17_swe.csv.columns)\n",
     "target_zones = upperColorado.target_zones_as_dict(target_zones)\n",
     "target_zones"
    ]
@@ -133,12 +133,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gunnison_compare = ZoneCompare(target_zones, gunnison_s17_swe.csv, swann_swe_target_zones)\n",
-    "plots = [gunnison_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
-    "all = hv.Layout(plots).cols(2)\n",
+    "compare = ZoneCompare(\n",
+    "    target_zones, \n",
+    "    s17_swe.csv, \n",
+    "    swann_swe_target_zones,\n",
+    "    range(1982, 2020)\n",
+    ")\n",
     "\n",
-    "# pn.pane.HoloViews(all).save('gunnison', embed=True, resources=INLINE)\n",
-    "# all"
+    "compare.save_html(HTML_OUTPUT + 'gunnison')"
    ]
   },
   {

--- a/notebooks/SWANN_salt.ipynb
+++ b/notebooks/SWANN_salt.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "cluster = start_cluster()"
+    "cluster = start_cluster(n_workers=20, local=False)"
    ]
   },
   {
@@ -151,8 +151,8 @@
     "plots = [salt_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
     "all = hv.Layout(plots).cols(2)\n",
     "\n",
-    "# pn.pane.HoloViews(all).save('salt', embed=True, resources=INLINE)\n",
-    "all"
+    "pn.pane.HoloViews(all).save('salt', embed=True, resources=INLINE)\n",
+    "# all"
    ]
   },
   {
@@ -164,6 +164,14 @@
    "source": [
     "cluster.shutdown()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "656df4ec-49c2-4474-8b0c-2177287612ec",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/SWANN_salt.ipynb
+++ b/notebooks/SWANN_salt.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "salt_s17_swe = Snow17SWE(\n",
+    "s17_swe = Snow17SWE(\n",
     "    SWE_HOME_DIR + 'CBRFC_Salt_1981_2020_SWE_inches.csv',\n",
     ")"
    ]
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "target_zones = list(salt_s17_swe.csv.columns)\n",
+    "target_zones = list(s17_swe.csv.columns)\n",
     "target_zones = lowerColorado.target_zones_as_dict(target_zones)\n",
     "target_zones"
    ]
@@ -147,12 +147,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "salt_compare = ZoneCompare(target_zones, salt_s17_swe.csv, swann_swe_target_zones)\n",
-    "plots = [salt_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
-    "all = hv.Layout(plots).cols(2)\n",
+    "compare = ZoneCompare(\n",
+    "    target_zones, \n",
+    "    s17_swe.csv, \n",
+    "    swann_swe_target_zones,\n",
+    "    range(1982, 2020)\n",
+    ")\n",
     "\n",
-    "pn.pane.HoloViews(all).save('salt', embed=True, resources=INLINE)\n",
-    "# all"
+    "compare.save_html(HTML_OUTPUT + 'salt')"
    ]
   },
   {
@@ -164,14 +166,6 @@
    "source": [
     "cluster.shutdown()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "656df4ec-49c2-4474-8b0c-2177287612ec",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/SWANN_verde.ipynb
+++ b/notebooks/SWANN_verde.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "cluster = start_cluster()"
+    "cluster = start_cluster(n_workers=20, local=False)"
    ]
   },
   {
@@ -151,8 +151,8 @@
     "plots = [verde_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
     "all = hv.Layout(plots).cols(2)\n",
     "\n",
-    "# pn.pane.HoloViews(all).save('verde', embed=True, resources=INLINE)\n",
-    "all"
+    "pn.pane.HoloViews(all).save('verde', embed=True, resources=INLINE)\n",
+    "# all"
    ]
   },
   {

--- a/notebooks/SWANN_verde.ipynb
+++ b/notebooks/SWANN_verde.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "verde_s17_swe = Snow17SWE(\n",
+    "s17_swe = Snow17SWE(\n",
     "    SWE_HOME_DIR + 'CBRFC_Verde_1981_2020_SWE_inches.csv',\n",
     ")"
    ]
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "target_zones = list(verde_s17_swe.csv.columns)\n",
+    "target_zones = list(s17_swe.csv.columns)\n",
     "target_zones = lowerColorado.target_zones_as_dict(target_zones)\n",
     "target_zones"
    ]
@@ -147,12 +147,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "verde_compare = ZoneCompare(target_zones, verde_s17_swe.csv, swann_swe_target_zones)\n",
-    "plots = [verde_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
-    "all = hv.Layout(plots).cols(2)\n",
+    "compare = ZoneCompare(\n",
+    "    target_zones, \n",
+    "    s17_swe.csv, \n",
+    "    swann_swe_target_zones,\n",
+    "    range(1982, 2020)\n",
+    ")\n",
     "\n",
-    "pn.pane.HoloViews(all).save('verde', embed=True, resources=INLINE)\n",
-    "# all"
+    "compare.save_html(HTML_OUTPUT + 'verde')"
    ]
   },
   {

--- a/notebooks/SWANN_virgin.ipynb
+++ b/notebooks/SWANN_virgin.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "cluster = start_cluster()"
+    "cluster = start_cluster(n_workers=20, local=False)"
    ]
   },
   {
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "virgin_s17_swe = Snow17SWE(\n",
+    "s17_swe = Snow17SWE(\n",
     "    SWE_HOME_DIR + 'CBRFC_Virgin_1981_2020_SWE_inches.csv',\n",
     ")"
    ]
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "target_zones = list(virgin_s17_swe.csv.columns)\n",
+    "target_zones = list(s17_swe.csv.columns)\n",
     "target_zones = lowerColorado.target_zones_as_dict(target_zones)\n",
     "target_zones"
    ]
@@ -147,12 +147,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "virgin_compare = ZoneCompare(target_zones, virgin_s17_swe.csv, swann_swe_target_zones)\n",
-    "plots = [virgin_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
-    "all = hv.Layout(plots).cols(2)\n",
+    "compare = ZoneCompare(\n",
+    "    target_zones, \n",
+    "    s17_swe.csv, \n",
+    "    swann_swe_target_zones,\n",
+    "    range(1982, 2020)\n",
+    ")\n",
     "\n",
-    "pn.pane.HoloViews(all).save('virgin', embed=True, resources=INLINE)\n",
-    "# all"
+    "compare.save_html(HTML_OUTPUT + 'virgin')"
    ]
   },
   {

--- a/notebooks/SWANN_virgin.ipynb
+++ b/notebooks/SWANN_virgin.ipynb
@@ -151,8 +151,8 @@
     "plots = [virgin_compare.plot_panels(zone) for zone in target_zones.keys()]\n",
     "all = hv.Layout(plots).cols(2)\n",
     "\n",
-    "# pn.pane.HoloViews(all).save('virgin', embed=True, resources=INLINE)\n",
-    "all"
+    "pn.pane.HoloViews(all).save('virgin', embed=True, resources=INLINE)\n",
+    "# all"
    ]
   },
   {

--- a/notebooks/nb_shared.py
+++ b/notebooks/nb_shared.py
@@ -10,9 +10,9 @@ BOKEH_OPTS = dict(
     cmap='viridis',
 )
 
-# Interactive HTML pages
-import panel as pn
-from bokeh.resources import INLINE
+hv.plotting.bokeh.ElementPlot.active_tools = [
+    'save', 'pan', 'box_zoom', 'reset'
+]
 
 # Jupyter Lab has missing PROJ envs
 import os

--- a/src/swe_compare/CbrfcZone.py
+++ b/src/swe_compare/CbrfcZone.py
@@ -1,9 +1,10 @@
 import geopandas as gpd
 import hvplot.pandas
 
+
 class CBRFCZone:
     ID_COLUMN = 'mask_ID'
-    
+
     def __init__(self, shapefile):
         self._shapefile = gpd.read_file(shapefile)
         self.assign_zone_id()
@@ -11,7 +12,7 @@ class CBRFCZone:
     @property
     def shapefile(self):
         return self._shapefile
-    
+
     def assign_zone_id(self):
         """
             Give each zone a unique ID as basis for a zone mask
@@ -20,17 +21,16 @@ class CBRFCZone:
 
     def target_zones_as_dict(self, target_zones):
         return {
-            record['zone']: record[self.ID_COLUMN] 
+            record['zone']: record[self.ID_COLUMN]
             for record in self.shapefile.query("zone in @target_zones")[
                 ["zone", self.ID_COLUMN]
             ].to_dict('records')
         }
 
     def explore_zones(self):
-        return zones_shp.explore(popup=['zone', 'mask_ID'])
-        
+        return self._shapefile.explore(popup=['zone', 'mask_ID'])
+
     def plot_zones(self):
         return self.shapefile.hvplot(
             c='mask_ID', color_key='Category10'
         ).opts(width=900, height=600)
-        

--- a/src/swe_compare/Snow17_SWE.py
+++ b/src/swe_compare/Snow17_SWE.py
@@ -1,12 +1,13 @@
 import pandas as pd
 
+
 class Snow17SWE:
     INCH_TO_MM = 25.4
     DTYPES = {
         'year': str, 'month': str, 'day': str
     }
     DATE_INDEX_FORMAT = '%Y-%m-%d'
-    
+
     def __init__(self, swe_csv):
         self._csv = pd.read_csv(
             swe_csv, header=0, dtype=self.DTYPES
@@ -20,13 +21,13 @@ class Snow17SWE:
 
     def create_time_index(self):
         self._csv['Date'] = pd.to_datetime(
-            self.csv.pop('year') + '-' + self.csv.pop('month') + '-' + self.csv.pop('day'),
+            self.csv.pop('year') + '-' + self.csv.pop('month') +
+            '-' + self.csv.pop('day'),
             format=self.DATE_INDEX_FORMAT
         )
-        
+
         self._csv = self.csv.drop('ztime', axis=1).set_index('Date')
-        
+
     def swe_to_mm(self):
         for key in self.csv.columns:
             self.csv[key] *= self.INCH_TO_MM
-        

--- a/src/swe_compare/nb_helpers.py
+++ b/src/swe_compare/nb_helpers.py
@@ -1,11 +1,33 @@
-from dask.distributed import Client
+import logging
+from dask.distributed import Client, SSHCluster
 
-def start_cluster(n_workers=10, memory_limit='4GB'):
-    cluster = Client(
-        n_workers=n_workers, 
-        threads_per_worker=1, 
-        memory_limit=memory_limit
-    )
+def start_cluster(n_workers=10, memory_limit='4GB', local=True):
+    if local:
+        cluster = Client(
+            n_workers=n_workers,
+            threads_per_worker=1,
+            memory_limit=memory_limit
+        )
+    else:
+        # NOTE:
+        # First host in the list is the scheduler, all others are workers
+        ssh_cluster = SSHCluster(
+            ["localhost", "honduras"],
+            connect_options={
+                "known_hosts": None,
+            },
+            worker_options={
+                "nthreads": 1,
+                "n_workers": n_workers,
+                "memory_limit": memory_limit,
+            },
+            scheduler_options={
+                "port": 0,
+                "dashboard_address": ":8797"
+            }
+        )
+        cluster = Client(ssh_cluster)
+        
     print(cluster.dashboard_link)
     return cluster
-    
+

--- a/src/swe_compare/nb_helpers.py
+++ b/src/swe_compare/nb_helpers.py
@@ -1,4 +1,3 @@
-import logging
 from dask.distributed import Client, SSHCluster
 
 

--- a/src/swe_compare/nb_helpers.py
+++ b/src/swe_compare/nb_helpers.py
@@ -1,6 +1,7 @@
 import logging
 from dask.distributed import Client, SSHCluster
 
+
 def start_cluster(n_workers=10, memory_limit='4GB', local=True):
     if local:
         cluster = Client(
@@ -27,7 +28,6 @@ def start_cluster(n_workers=10, memory_limit='4GB', local=True):
             }
         )
         cluster = Client(ssh_cluster)
-        
+
     print(cluster.dashboard_link)
     return cluster
-

--- a/src/swe_compare/rasterize_zone.py
+++ b/src/swe_compare/rasterize_zone.py
@@ -11,15 +11,15 @@ def cbrfc_zone_mask(zone_raster, zone_shape):
     with rasterio.open(zone_raster) as zone_tif:
         transform = zone_tif.transform
         shape = zone_tif.shape
-    
+
     zone_geometries = (
-        (mapping(geometry), value) 
+        (mapping(geometry), value)
         for geometry, value in zip(
-            zone_shape.shapefile.geometry, 
+            zone_shape.shapefile.geometry,
             zone_shape.shapefile[zone_shape.ID_COLUMN]
         )
     )
-    
+
     return features.rasterize(
         zone_geometries,
         transform=transform,
@@ -32,20 +32,20 @@ def cbrfc_zone_mask(zone_raster, zone_shape):
 def zone_tif_lons_lats(zone_raster_file):
     with rasterio.open(zone_raster_file) as zone_raster:
         cols, rows = np.meshgrid(
-            np.arange(zone_raster.width), 
+            np.arange(zone_raster.width),
             np.arange(zone_raster.height)
         )
         x, y = rasterio.transform.xy(
             zone_raster.transform, rows, cols
         )
-        
+
     return np.array(x), np.array(y)
-        
+
 
 def cbrfc_zone_mask_as_xr(zone_raster, zone_shape):
     zones_mask = cbrfc_zone_mask(zone_raster, zone_shape)
     lons, lats = zone_tif_lons_lats(zone_raster)
-    
+
     cbrfc_zones = xr.Dataset({
         "zone": xr.DataArray(
             data=zones_mask,
@@ -60,6 +60,3 @@ def cbrfc_zone_mask_as_xr(zone_raster, zone_shape):
     cbrfc_zones = cbrfc_zones.where(cbrfc_zones['zone'] != MASK_NO_ZONE)
     # lat coordinates are flipped for some unknown reason
     return cbrfc_zones.reindex(lat=cbrfc_zones.lat[::-1])
-    
-    
-

--- a/src/swe_compare/rasterize_zone.py
+++ b/src/swe_compare/rasterize_zone.py
@@ -6,13 +6,75 @@ from rasterio import features
 from shapely.geometry import mapping
 
 MASK_NO_ZONE = -999
+RASTERIZE_OPTIONS = dict(
+    all_touched=True,
+    fill=MASK_NO_ZONE,
+    dtype=rasterio.int16
+)
 
 
-def cbrfc_zone_mask(zone_raster, zone_shape):
+def rasterize_cbrfc_zone(zone_raster, zone_geometries):
+    """
+    Convert collection of CBRFC zone into a raster.
+
+    Use rasterio to convert given zone geometries (polygons) into a gridded
+    version defined by the given zone raster.
+
+    TODO: Look into replacing with native GDAL
+          https://gdal.org/api/python/utilities.html#osgeo.gdal.RasterizeLayer
+
+    Parameters
+    ----------
+    zone_raster : String
+        Path to raster file
+    zone_geometries : Iterable
+        List of geometries to convert
+
+    Returns
+    -------
+    TYPE
+        DESCRIPTION.
+
+    """
     with rasterio.open(zone_raster) as zone_tif:
         transform = zone_tif.transform
         shape = zone_tif.shape
 
+    return features.rasterize(
+        zone_geometries,
+        transform=transform,
+        out_shape=shape,
+        **RASTERIZE_OPTIONS
+    )
+
+
+def single_cbrfc_zone_mask(zone_raster, zone_gpd):
+    """
+    Convert a single CBRFC zone into a raster.
+
+    This will convert the first row of the given geopandas dataframe only.
+
+    Parameters
+    ----------
+    zone_raster : String
+        Path to raster file
+    zone_gpd : geopandas dataframe
+        Dataframe holding the geometries
+
+    Returns
+    -------
+    TYPE
+        DESCRIPTION.
+
+    """
+    zone_geometry = [
+        (mapping(zone_gpd.iloc[0].geometry), 1)
+    ]
+
+    return rasterize_cbrfc_zone(zone_raster, zone_geometry)
+
+
+def cbrfc_zone_mask(zone_raster, zone_shape):
     zone_geometries = (
         (mapping(geometry), value)
         for geometry, value in zip(
@@ -21,14 +83,7 @@ def cbrfc_zone_mask(zone_raster, zone_shape):
         )
     )
 
-    return features.rasterize(
-        zone_geometries,
-        transform=transform,
-        out_shape=shape,
-        all_touched=True,
-        fill=MASK_NO_ZONE,
-        dtype=rasterio.int16
-    )
+    return rasterize_cbrfc_zone(zone_raster, zone_geometries)
 
 
 def zone_tif_lons_lats(zone_raster_file):
@@ -44,13 +99,12 @@ def zone_tif_lons_lats(zone_raster_file):
     return np.array(x), np.array(y)
 
 
-def cbrfc_zone_mask_as_xr(zone_raster, zone_shape):
-    zones_mask = cbrfc_zone_mask(zone_raster, zone_shape)
+def zone_mask_as_xr(zone_raster, zone_mask):
     lons, lats = zone_tif_lons_lats(zone_raster)
 
     cbrfc_zones = xr.Dataset({
         "zone": xr.DataArray(
-            data=zones_mask,
+            data=zone_mask,
             dims=['lat', 'lon'],
             coords={
                 'lat': (['lat'], lats[:, 0]),
@@ -62,3 +116,13 @@ def cbrfc_zone_mask_as_xr(zone_raster, zone_shape):
     cbrfc_zones = cbrfc_zones.where(cbrfc_zones['zone'] != MASK_NO_ZONE)
     # lat coordinates are flipped for some unknown reason
     return cbrfc_zones.reindex(lat=cbrfc_zones.lat[::-1])
+
+
+def cbrfc_zone_mask_as_xr(zone_raster, zone_shape):
+    zones_mask = cbrfc_zone_mask(zone_raster, zone_shape)
+    return zone_mask_as_xr(zone_raster, zones_mask)
+
+
+def single_cbrfc_zone_mask_as_xr(zone_raster, zone_gpd):
+    zones_mask = single_cbrfc_zone_mask(zone_raster, zone_gpd)
+    return zone_mask_as_xr(zone_raster, zones_mask)

--- a/src/swe_compare/rasterize_zone.py
+++ b/src/swe_compare/rasterize_zone.py
@@ -7,6 +7,7 @@ from shapely.geometry import mapping
 
 MASK_NO_ZONE = -999
 
+
 def cbrfc_zone_mask(zone_raster, zone_shape):
     with rasterio.open(zone_raster) as zone_tif:
         transform = zone_tif.transform
@@ -28,6 +29,7 @@ def cbrfc_zone_mask(zone_raster, zone_shape):
         fill=MASK_NO_ZONE,
         dtype=rasterio.int16
     )
+
 
 def zone_tif_lons_lats(zone_raster_file):
     with rasterio.open(zone_raster_file) as zone_raster:

--- a/src/swe_compare/swann_helpers.py
+++ b/src/swe_compare/swann_helpers.py
@@ -38,12 +38,16 @@ def swann_swe_for_zones(
     cbrfc_zone_shape,
     target_zones_dict,
 ):
-    target_cbrfc_zones = cbrfc_zone_mask_as_xr(cbrfc_zone_tif, cbrfc_zone_shape)
+    target_cbrfc_zones = cbrfc_zone_mask_as_xr(
+        cbrfc_zone_tif, cbrfc_zone_shape
+    )
+
     # Reduce to zones of interest
     target_cbrfc_zones = target_cbrfc_zones.where(
         target_cbrfc_zones.isin(list(target_zones_dict.values())),
         drop=True
     )
+
     # Get SWE values for bounding box of target zones
     swann = xr.open_mfdataset(swann_files, parallel=True).sel(
         target_bounding_box(target_cbrfc_zones)
@@ -56,7 +60,6 @@ def swann_swe_for_zones(
     )
 
     swann_cbrfc_zones = combine_cbrfc_swann(swann, target_cbrfc_zones)
-
 
     return swann_cbrfc_zones.where(
         swann_cbrfc_zones.zone.isin(

--- a/src/swe_compare/swann_helpers.py
+++ b/src/swe_compare/swann_helpers.py
@@ -1,31 +1,63 @@
+import math
+import numpy as np
 import xarray as xr
 
 from .rasterize_zone import cbrfc_zone_mask_as_xr
 
 
-def combine_cbrfc_swann(swann_files, cbrfc_zones):
+def target_bounding_box(target_zones):
+    lon_box = slice(
+        math.floor(target_zones.lon.values.min()),
+        math.ceil(target_zones.lon.values.max())
+    )
+    lat_box = slice(
+        math.floor(target_zones.lat.values.min()),
+        math.ceil(target_zones.lat.values.max())
+    )
+    return dict(lat=lat_box, lon=lon_box)
+
+
+def combine_cbrfc_swann(swann, cbrfc_zones):
     """
-        Combines CBRFC mask with SWANN SWE and 
+        Combines CBRFC mask with SWANN SWE and
         computes the CBRFC zonal mean.
     """
     return xr.combine_by_coords(
         [
-            xr.open_mfdataset(swann_files, parallel=True),
-            cbrfc_zones
-        ], 
-        coords=['lat', 'lon'], 
-        join='override'
+            cbrfc_zones,
+            swann,
+        ],
+        coords=['lat', 'lon'],
+        join='inner'
     ).groupby('zone').mean()
 
 
 def swann_swe_for_zones(
-    swann_files, 
+    swann_files,
     cbrfc_zone_tif,
     cbrfc_zone_shape,
-    target_zones_dict
+    target_zones_dict,
 ):
-    cbrfc_zones = cbrfc_zone_mask_as_xr(cbrfc_zone_tif, cbrfc_zone_shape)
-    swann_cbrfc_zones = combine_cbrfc_swann(swann_files, cbrfc_zones)
+    target_cbrfc_zones = cbrfc_zone_mask_as_xr(cbrfc_zone_tif, cbrfc_zone_shape)
+    # Reduce to zones of interest
+    target_cbrfc_zones = target_cbrfc_zones.where(
+        target_cbrfc_zones.isin(list(target_zones_dict.values())),
+        drop=True
+    )
+    # Get SWE values for bounding box of target zones
+    swann = xr.open_mfdataset(swann_files, parallel=True).sel(
+        target_bounding_box(target_cbrfc_zones)
+    )
+
+    swann = swann.interp(
+        lat=target_cbrfc_zones.lat.values,
+        lon=target_cbrfc_zones.lon.values,
+        method='nearest'
+    )
+
+    swann_cbrfc_zones = combine_cbrfc_swann(swann, target_cbrfc_zones)
+
+
     return swann_cbrfc_zones.where(
         swann_cbrfc_zones.zone.isin(
             list(target_zones_dict.values())

--- a/src/swe_compare/zone_compare.py
+++ b/src/swe_compare/zone_compare.py
@@ -4,6 +4,7 @@ import panel as pn
 
 from bokeh.resources import INLINE
 
+
 class ZoneCompare:
     def __init__(self, target_zones, cbrfc_swe, swann_swe, year_range):
         self.target_zones = target_zones
@@ -13,17 +14,18 @@ class ZoneCompare:
             [f'{year}-03-01' for year in year_range]
         )
 
-
     def plot_panels(self, name):
         zone_ID = self.target_zones[name]
-        axes_limits=(-20, 1000)
+        axes_limits = (-20, 1000)
 
         swann_data = self.swann_swe.sel(zone=zone_ID)
 
         snow_17_m1 = self.cbrfc_swe.loc[self.year_range][name].values
         swann_m1 = swann_data.loc[self.year_range].values
 
-        correlation = str(f'{pd.Series(snow_17_m1).corr(pd.Series(swann_m1)):.3}')
+        correlation = str(
+            f'{pd.Series(snow_17_m1).corr(pd.Series(swann_m1)):.3}'
+        )
 
         scatter = hv.Overlay([
             hv.Slope(1, 0).opts(color='orange'),
@@ -46,11 +48,9 @@ class ZoneCompare:
         ])
         return hv.Layout(time_series + scatter).cols(1)
 
-
     def show_all(self):
         plots = [self.plot_panels(zone) for zone in self.target_zones.keys()]
         return hv.Layout(plots).opts(shared_axes=False).cols(2)
-
 
     def save_html(self, file_path):
         """
@@ -61,4 +61,3 @@ class ZoneCompare:
         ).save(
             file_path, embed=True, resources=INLINE
         )
-

--- a/src/swe_compare/zone_compare.py
+++ b/src/swe_compare/zone_compare.py
@@ -1,5 +1,8 @@
 import holoviews as hv
 import pandas as pd
+import panel as pn
+
+from bokeh.resources import INLINE
 
 class ZoneCompare:
     def __init__(self, target_zones, cbrfc_swe, swann_swe, year_range):
@@ -42,3 +45,20 @@ class ZoneCompare:
             swann_data.hvplot('time', label=f'SWANN')
         ])
         return hv.Layout(time_series + scatter).cols(1)
+
+
+    def show_all(self):
+        plots = [self.plot_panels(zone) for zone in self.target_zones.keys()]
+        return hv.Layout(plots).opts(shared_axes=False).cols(2)
+
+
+    def save_html(self, file_path):
+        """
+        Save plots as interactive HTML page
+        """
+        pn.pane.HoloViews(
+            self.show_all()
+        ).save(
+            file_path, embed=True, resources=INLINE
+        )
+

--- a/src/swe_compare/zone_compare.py
+++ b/src/swe_compare/zone_compare.py
@@ -2,33 +2,34 @@ import holoviews as hv
 import pandas as pd
 
 class ZoneCompare:
-    MARCH_1st = pd.to_datetime([f'{year}-03-01' for year in range(1992, 2020)])
-    
-    def __init__(self, target_zones, cbrfc_swe, swann_swe):
+    def __init__(self, target_zones, cbrfc_swe, swann_swe, year_range):
         self.target_zones = target_zones
         self.cbrfc_swe = cbrfc_swe
         self.swann_swe = swann_swe
+        self.year_range = pd.to_datetime(
+            [f'{year}-03-01' for year in year_range]
+        )
 
-    
+
     def plot_panels(self, name):
         zone_ID = self.target_zones[name]
         axes_limits=(-20, 1000)
-    
+
         swann_data = self.swann_swe.sel(zone=zone_ID)
-    
-        snow_17_m1 = self.cbrfc_swe.loc[self.MARCH_1st][name].values
-        swann_m1 = swann_data.loc[self.MARCH_1st].values
-    
+
+        snow_17_m1 = self.cbrfc_swe.loc[self.year_range][name].values
+        swann_m1 = swann_data.loc[self.year_range].values
+
         correlation = str(f'{pd.Series(snow_17_m1).corr(pd.Series(swann_m1)):.3}')
-        
+
         scatter = hv.Overlay([
             hv.Slope(1, 0).opts(color='orange'),
             hv.Scatter(
                 list(zip(snow_17_m1, swann_m1))
             ).opts(
                 xlim=axes_limits, ylim=axes_limits,
-                title=f'{name} - March 1st SWE',  xlabel='CBRFC SWE (mm)',  ylabel='SWANN SWE (mm)', 
-                color='k', size=10, 
+                title=f'{name} - March 1st SWE',  xlabel='CBRFC SWE (mm)',  ylabel='SWANN SWE (mm)',
+                color='k', size=10,
                 width=500, height=500
             ) * hv.Text(300, 10, correlation),
         ])
@@ -36,7 +37,7 @@ class ZoneCompare:
             self.cbrfc_swe[name].hvplot().opts(
                 ylim=(-20, None),
                 title=name, ylabel='SWE (mm)',
-                width=1200, height=600, 
+                width=1200, height=600,
             ),
             swann_data.hvplot('time', label=f'SWANN')
         ])


### PR DESCRIPTION
Change comparison logic to use the given resolution via the CBRFC zone tif file. Also adds a new notebook to compare values from the Gunnison.

Merging this with a semi-incomplete state to preserve some code. The extraction of corresponding SWE grid cells with a CBRFC zone shape is not 100%. A new branch using SQL and PostGIS is showing a more promising solution and is the focus going forward.