### PR TITLE
iSnobal to Zarr

### DIFF
--- a/notebooks/data_prepare/iSnobal_to_zarr.ipynb
+++ b/notebooks/data_prepare/iSnobal_to_zarr.ipynb
@@ -8,9 +8,15 @@
    "outputs": [],
    "source": [
     "import xarray as xr\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
     "import zarr\n",
-    "from zarr.codecs import BloscCodec\n",
     "import glob\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from zarr.codecs import BloscCodec, BloscShuffle\n",
+    "\n",
     "from swed_17.nb_helpers import start_cluster"
    ]
   },
@@ -21,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster = start_cluster(n_workers=12, memory_limit=\"8GB\", local=False)"
+    "cluster = start_cluster(n_workers=12, memory_limit=\"16GB\")"
    ]
   },
   {
@@ -34,8 +40,70 @@
     "BASE_DIR = \"/perc10/data/cbrfcSnowModel/\"\n",
     "SNOBAL_DIR = BASE_DIR + \"isnobal\"\n",
     "\n",
-    "WATER_YEAR = \"2021\"\n",
-    "BASIN = \"colkrem\""
+    "\n",
+    "# COLKREM\n",
+    "# BASIN = \"colkrem\"\n",
+    "# CHUNKS = (1, 1450, 1100)\n",
+    "# SHARDS = (10, 1450, 1100)\n",
+    "# XR_CHUNKS = {\"time\": 10, \"y\": 725, \"x\": 550}\n",
+    "# ERW\n",
+    "# BASIN = \"erw_ext\"\n",
+    "# CHUNKS = (1, 1038, 1346)\n",
+    "# SHARDS = (10, 1038, 1346)\n",
+    "# XR_CHUNKS = {\"time\": 10, \"y\": 519, \"x\": 673}\n",
+    "# SWO\n",
+    "# BASIN = \"swco\"\n",
+    "# CHUNKS = (1, 783, 744)\n",
+    "# SHARDS = (10, 783, 744)\n",
+    "# XR_CHUNKS = {\"time\": 10, \"y\": 783, \"x\": 744}\n",
+    "# # Yampa\n",
+    "# BASIN = \"yampa\"\n",
+    "# CHUNKS = (1, 1043, 952)\n",
+    "# SHARDS = (10, 1043, 952)\n",
+    "# XR_CHUNKS = {\"time\": 10, \"y\": 1043, \"x\": 952}\n",
+    "# Uppergreen\n",
+    "# BASIN = \"uppergreen\"\n",
+    "# CHUNKS = (1, 365, 517)\n",
+    "# SHARDS = (10, 1825, 1551)\n",
+    "# XR_CHUNKS = {\"time\": 10, \"y\": 1825, \"x\": 1551}\n",
+    "# Great Basin\n",
+    "# BASIN = \"great_basin\"\n",
+    "# CHUNKS = (1, 591, 539)\n",
+    "# SHARDS = (10, 2364, 2156)\n",
+    "# XR_CHUNKS = {\"time\": 10, \"y\": 2362, \"x\": 2156}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec433f5-544b-4a02-b87a-23e1845f6017",
+   "metadata": {},
+   "source": [
+    "### Add October 1st 00:00 to create identical sets of five timesteps per day"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c603c589-e846-4e9e-93a9-688c27cd3b61",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "for file in [\"snow\", \"em\"]:\n",
+    "    file = SNOBAL_DIR + f\"/wy2026/{BASIN}/run20251001/{file}.nc\"\n",
+    "    ds = xr.open_dataset(file)\n",
+    "\n",
+    "    october_1st = pd.Timestamp(\"2025-10-01T00:00:00\")\n",
+    "    index = pd.DatetimeIndex([october_1st]).append(ds.indexes[\"time\"])\n",
+    "\n",
+    "    ds.reindex(time=index, fill_value=np.nan).to_netcdf(file + \"_new\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85059ddb-6749-4fd0-9b5e-64a5ce6d8280",
+   "metadata": {},
+   "source": [
+    "### Process all datasets"
    ]
   },
   {
@@ -45,10 +113,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "snow = sorted(glob.glob(SNOBAL_DIR + f\"/wy{WATER_YEAR}/{BASIN}/run*/snow.nc\"))\n",
-    "em = sorted(glob.glob(SNOBAL_DIR + f\"/wy{WATER_YEAR}/{BASIN}/run*/em.nc\"))\n",
+    "snow = sorted(glob.glob(SNOBAL_DIR + f\"/wy202*/{BASIN}/run*/snow.nc\"))\n",
+    "em = sorted(glob.glob(SNOBAL_DIR + f\"/wy202*/{BASIN}/run*/em.nc\"))\n",
     "\n",
-    "OUTPUT_ZARR_PATH = SNOBAL_DIR + f\"/isnobal/wy{WATER_YEAR}_{BASIN}.zarr\""
+    "OUTPUT_ZARR_PATH = SNOBAL_DIR + f\"/zarr_archive/toposplit/{BASIN}.zarr\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f82df7a8-a974-4a80-8c2e-ecd391d948de",
+   "metadata": {},
+   "source": [
+    "### For existing archives"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14ee4bb6-3182-4fa5-a53b-b60279137f26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if Path(OUTPUT_ZARR_PATH).exists():\n",
+    "    zarr_archive = xr.open_mfdataset(\n",
+    "        OUTPUT_ZARR_PATH,\n",
+    "        parallel=True,\n",
+    "        chunks=None,\n",
+    "        engine=\"zarr\",\n",
+    "    )\n",
+    "    archive_mode = \"a\"\n",
+    "else:\n",
+    "    zarr_archive = None\n",
+    "    archive_mode = \"w\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee5e0ec0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr_archive"
    ]
   },
   {
@@ -60,11 +166,50 @@
    "source": [
     "ds = xr.open_mfdataset(\n",
     "    snow + em,\n",
-    "    combine='by_coords',\n",
+    "    combine=\"by_coords\",\n",
     "    data_vars=\"all\",\n",
     "    compat=\"no_conflicts\",\n",
-    "    parallel=True\n",
-    ")"
+    "    parallel=True,\n",
+    ").chunk(XR_CHUNKS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "038a871f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b1fd167-afbe-454d-8f14-c466fa651e28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_dates = np.setdiff1d(ds.time, zarr_archive.time)\n",
+    "missing_dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea13c2ce-ac01-4225-afe6-d6441721ce75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = ds.sel(time=missing_dates)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19fefee4-95fa-49a6-8ac4-b665b0bcbad3",
+   "metadata": {},
+   "source": [
+    "### Zarr Conversion"
    ]
   },
   {
@@ -74,15 +219,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "compressor = BloscCodec(cname=\"zlib\", clevel=4, shuffle=zarr.codecs.BloscShuffle.bitshuffle)\n",
+    "encoding = None\n",
+    "projection = None\n",
     "\n",
-    "encoding = {}\n",
-    "for var_name in ds.data_vars:\n",
-    "    encoding[var_name] = {\n",
-    "        'compressors': compressor,\n",
-    "    }\n",
-    "for coord_name in ds.coords:\n",
-    "    encoding[coord_name] = {'compressors': compressor}"
+    "# Reset all encoding\n",
+    "for var in ds.variables:\n",
+    "    ds[var].encoding = {}\n",
+    "\n",
+    "if zarr_archive is None:\n",
+    "    encoding = {}\n",
+    "    compression = BloscCodec(\n",
+    "        cname=\"lz4\", clevel=5, shuffle=BloscShuffle.shuffle\n",
+    "    )\n",
+    "\n",
+    "    for var_name in ds.data_vars:\n",
+    "        if ds[var_name].ndim == 3:\n",
+    "            encoding[var_name] = {\n",
+    "                \"chunks\": CHUNKS,\n",
+    "                \"shards\": SHARDS,\n",
+    "                \"compressors\": compression,\n",
+    "            }\n",
+    "        else:\n",
+    "            encoding[var_name] = {\"chunks\": ds[var_name].shape}\n",
+    "\n",
+    "    projection = xr.DataArray(0, attrs=ds.projection.attrs).squeeze(drop=True)\n",
+    "    ds = ds.drop_vars(\"projection\").assign_coords(projection=projection)\n",
+    "else:\n",
+    "    # Projection is a static variable in the Zarr archive\n",
+    "    del ds[\"projection\"]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d7d10af-21a2-4982-8c5c-94d1637de3b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbb885c0",
+   "metadata": {},
+   "source": [
+    "#### Append all data at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a175eb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_opts = {}\n",
+    "if archive_mode == \"a\":\n",
+    "    write_opts[\"append_dim\"] = \"time\""
    ]
   },
   {
@@ -94,9 +288,59 @@
    "source": [
     "ds.to_zarr(\n",
     "    OUTPUT_ZARR_PATH,\n",
-    "    mode='w',\n",
-    "    encoding=encoding\n",
+    "    mode=archive_mode,\n",
+    "    encoding=encoding,\n",
+    "    zarr_format=3,\n",
+    "    consolidated=True,\n",
+    "    **write_opts,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b3bafbf",
+   "metadata": {},
+   "source": [
+    "#### Overwrite a region when a first attempt failed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a993acd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ds = ds.isel(time=slice(-35, None))\n",
+    "# ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2953612d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# zarr_archive.isel(time=slice(-35, None))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6eaa00ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ds.drop_vars([\"x\", \"y\"]).to_zarr(\n",
+    "#     OUTPUT_ZARR_PATH,\n",
+    "#     region={\n",
+    "#         \"time\": slice(\n",
+    "#             zarr_archive.time.shape[0] - ds.time.shape[0],\n",
+    "#             zarr_archive.time.shape[0],\n",
+    "#         ),\n",
+    "#     },\n",
+    "# )"
    ]
   },
   {
@@ -112,17 +356,174 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "327fa3fe-f955-464f-bc9b-b22063c3b2bb",
+   "id": "c4c488da",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "zarr.consolidate_metadata(OUTPUT_ZARR_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "000008a4",
+   "metadata": {},
+   "source": [
+    "## Archive fixes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "022a0bd5",
+   "metadata": {},
+   "source": [
+    "### Make projection statis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26b6a71e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs = zarr.open(OUTPUT_ZARR_PATH, mode=\"a\")\n",
+    "attributes = dict(zs[\"projection\"].attrs)\n",
+    "zs[\"projection\"].metadata.dimension_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2064621",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0c58196",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del zs[\"projection\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adbf3938",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "projection = zs.create_array(\n",
+    "    name=\"projection\",\n",
+    "    shape=(),\n",
+    "    dtype=\"int32\",\n",
+    "    fill_value=0,\n",
+    "    dimension_names=[],\n",
+    ")\n",
+    "projection.attrs.update(attributes)\n",
+    "projection.attrs[\"_ARRAY_DIMENSIONS\"] = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "603f31e8",
+   "metadata": {},
+   "source": [
+    "### List variables from archive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12d52ae3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs = zarr.open(OUTPUT_ZARR_PATH, mode=\"a\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e51c5f4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, arr in zs.arrays():\n",
+    "    print(name)\n",
+    "    print(arr.shape)\n",
+    "    # if 2000 < arr.shape[0] < 8539:\n",
+    "    #     print(name)\n",
+    "    #  arr.resize((8539,) + arr.shape[1:])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b291665d",
+   "metadata": {},
+   "source": [
+    "### Resize one variable dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c256dbac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs = zarr.open(OUTPUT_ZARR_PATH, mode=\"a\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df239b38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs[\"temp_snowcover\"].resize((8294, 1043, 952))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a31dddf6",
+   "metadata": {},
+   "source": [
+    "### Only keep unique values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0d5270e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a24c4b52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs[:] = np.unique(zs[:])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "snow-viz",
+   "display_name": "snow_viz",
    "language": "python",
-   "name": "snow-viz"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -134,7 +535,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/data_prepare/iSnobal_to_zarr.ipynb
+++ b/notebooks/data_prepare/iSnobal_to_zarr.ipynb
@@ -376,7 +376,7 @@
    "id": "022a0bd5",
    "metadata": {},
    "source": [
-    "### Make projection statis"
+    "### Make projection a static attribute"
    ]
   },
   {

--- a/src/swed_17/nb_helpers.py
+++ b/src/swed_17/nb_helpers.py
@@ -6,7 +6,8 @@ def start_cluster(n_workers=10, memory_limit='4GB', local=True):
         cluster = Client(
             n_workers=n_workers,
             threads_per_worker=1,
-            memory_limit=memory_limit
+            memory_limit=memory_limit,
+            dashboard_address=":8797",
         )
     else:
         # NOTE:


### PR DESCRIPTION
Update the logic that converts iSnobal NetCDF output to a central Zarr archive per basin.